### PR TITLE
APPDESCRIP-25: Update existing application repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # app-edge-complete
 
-Application descriptor repository for app-edge-complete.  Comprised entirely of edge modules.
+Application descriptor repository for app-edge-complete. Comprised entirely of edge modules.
 
 ## Modules
 
-| Module name                 |
-|:----------------------------|
-| `edge-orders`               |
-| `edge-connexion`            |
-| `edge-oai-pmh`              |
-| `edge-dematic`              |
-| `edge-caiasoft`             |
-| `edge-rtac`                 |
-| `edge-sip2`                 |
-| `edge-fqm`                  |
-| `edge-patron`               |
-| `edge-courses`              |
-| `edge-dcb`                  |
+| Module name      |
+|:-----------------|
+| `edge-orders`    |
+| `edge-connexion` |
+| `edge-oai-pmh`   |
+| `edge-dematic`   |
+| `edge-caiasoft`  |
+| `edge-rtac`      |
+| `edge-sip2`      |
+| `edge-fqm`       |
+| `edge-patron`    |
+| `edge-courses`   |
+| `edge-ncip`      |
+| `edge-dcb`       |
 
 ## UI Modules
 

--- a/app-edge-complete.template.json
+++ b/app-edge-complete.template.json
@@ -51,6 +51,10 @@
       "version": "latest"
     },
     {
+      "name": "edge-ncip",
+      "version": "latest"
+    },
+    {
       "name": "edge-dcb",
       "version": "latest"
     }


### PR DESCRIPTION
### Purpose
- Bring the HEAD/master of these repos up to date (set of modules, application dependencies, application version in pom.xml, etc.).
- See [application-descriptors/Quesnelia at Quesnelia.SP1 · folio-org/application-descriptors](https://github.com/folio-org/application-descriptors/tree/Quesnelia.SP1/Quesnelia) 
- The module versions in the master branch should be “latest” to allow for snapshot versions of the application descriptors to be generated.

[APPDESCRIP-25](https://folio-org.atlassian.net/browse/APPDESCRIP-25)